### PR TITLE
SITEOPS-129194 add strongdm-app to the list of containers allowed to run binaries not contained in the base container image

### DIFF
--- a/cloud-native/falco/templates/custom.local.yaml
+++ b/cloud-native/falco/templates/custom.local.yaml
@@ -34,4 +34,4 @@ customRules:
 
     - rule: Drop and execute new binary in container
       append: true
-      condition: and not container.name in (cloud-sql-proxy-job)
+      condition: and not container.name in (cloud-sql-proxy-job, strongdm-app)


### PR DESCRIPTION
This change has been applied successfully in the alpha, dev, stage and prod environments.
